### PR TITLE
Fix setting not working

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,9 +76,9 @@ export const createDecoration = (
   let renderLine = vscode.workspace.getConfiguration('lineHighlightBookmark').get('renderLine', true);
   if (renderLine) {
 
-    const borderColor: string = vscode.workspace.getConfiguration('lineHighlightBookmark').get('borderColor', "#65EAB9");
-    const borderWidth = vscode.workspace.getConfiguration('lineHighlightBookmark').get("borderWidth", "2px");
-    const borderStyle = vscode.workspace.getConfiguration('lineHighlightBookmark').get("borderStyle", "solid");
+    const borderColor: string = vscode.workspace.getConfiguration('lineHighlightBookmark').get('lineColor', "#65EAB9");
+    const borderWidth = vscode.workspace.getConfiguration('lineHighlightBookmark').get("lineWidth", "2px");
+    const borderStyle = vscode.workspace.getConfiguration('lineHighlightBookmark').get("lineStyle", "solid");
 
     const decorationOptions: vscode.DecorationRenderOptions = {
       gutterIconPath: context.asAbsolutePath('images/icon.svg'),


### PR DESCRIPTION
keys in setting were lineColor, lineStyle and lineWidth, but utils.ts expected borderColor, borderStyle and borderWidth. So settings didn't work unless you manually set "lineHighlightBookmark.borderStyle" instead of the key VSCode expected and settings set, "lineHighlightBookmark.lineStyle".
I simply renamed everything to line instead of border.